### PR TITLE
Emphasize user count over financials

### DIFF
--- a/app/assets/stylesheets/_global.scss
+++ b/app/assets/stylesheets/_global.scss
@@ -193,11 +193,26 @@ $table_body_height: 74px;
 .counter-container {
   float: right;
 
+  .large-text {
+    color: #FF851B;
+    font-size: 30px;
+    font-weight: bold;
+    position: relative;
+    right: 2px;
+    top: 2px;
+  }
+
   .user-counter {
-    float: right;
-    font-size: 16px;
+    font-size: 18px;
     position: relative;
     top: -5px;
+  }
+
+  .call-to-action {
+    font-size: 17px;
+    position: relative;
+    text-align: center;
+    top: -7px;
   }
 }
 
@@ -270,12 +285,6 @@ $table_body_height: 74px;
     font-size: 18px;
     line-height: 28px;
   }
-}
-
-.large-text {
-  font-size: 28px;
-  color: #FF851B;
-  font-weight: bold;
 }
 
 .highlight {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,9 +31,12 @@
       </span>
     </a>
     <div class="counter-container">
-      <div><span class="large-text"><%= @total_donated %></span> raised for charity (so far!)</div>
-      <div class="user-counter"><span id="user-count"><%= @n_miners %></span> <span id="user-count-units">computer<%= "s" unless @n_miners == 1 %></span>
-        helping right now</div>
+      <div class="user-counter">
+        <span id="user-count" class="large-text"><%= @n_miners %></span>
+        <span id="user-count-units">computer<%= "s" unless @n_miners == 1 %></span>
+        helping right now
+      </div>
+      <div class="call-to-action">Help us get to 100!</div>
     </div>
   </nav>
   <%= yield %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,4 +41,10 @@ Rails.application.configure do
 
   # Use a different logger for development.
   config.logger = Logger.new(STDOUT)
+
+  # Load Redis in development using same code as in production.
+  redis_connections_per_process = Integer(ENV["REDIS_CONNS_PER_PROCESS"] || 5)
+  $redis = ConnectionPool.new(size: redis_connections_per_process) do
+    Redis.new(url: ENV["REDIS_URL"] || "redis://localhost:6379/0")
+  end
 end


### PR DESCRIPTION
Until the financials actually grow regularly, it's not helpful to have the same low number in big text. Instead, we highlight the user count, which gets users involved.
