### PR TITLE
Remove `coinbase` dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 ruby ENV["RUBY_VERSION"] || "2.2.0"
 
 gem "attr_encrypted", "~> 1.3"
-gem "coinbase", github: "coinbase/coinbase-ruby", ref: "23f44e6"
 gem "connection_pool", "~> 2.2"
 gem "dwolla-ruby", "~> 2.6"
 gem "memoist", "~> 0.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: git://github.com/coinbase/coinbase-ruby.git
-  revision: 23f44e69140a4d71d06f7703a154b2a7c6d8e8f5
-  ref: 23f44e6
-  specs:
-    coinbase (2.1.1)
-      hashie (>= 1.2.0)
-      httparty (>= 0.8.3)
-      monetize (~> 1.0)
-      money (~> 6.0)
-      multi_json (>= 1.3.4)
-      oauth2 (~> 1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -85,8 +72,6 @@ GEM
     encryptor (1.3.0)
     erubis (2.7.0)
     execjs (2.5.2)
-    faraday (0.9.1)
-      multipart-post (>= 1.2, < 3)
     fast_stack (0.1.0)
       rake
       rake-compiler
@@ -98,17 +83,12 @@ GEM
       activesupport (>= 4.1.0)
     haml (4.0.6)
       tilt
-    hashie (3.4.2)
     highline (1.6.21)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    httparty (0.13.5)
-      json (~> 1.8)
-      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     iniparse (1.4.0)
     json (1.8.3)
-    jwt (1.5.1)
     loofah (2.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -127,18 +107,10 @@ GEM
       money (~> 6.5.0)
       railties (>= 3.0)
     multi_json (1.11.2)
-    multi_xml (0.5.5)
-    multipart-post (2.0.0)
     netrc (0.10.3)
     newrelic_rpm (3.12.1.298)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    oauth2 (1.0.0)
-      faraday (>= 0.8, < 0.10)
-      jwt (~> 1.0)
-      multi_json (~> 1.3)
-      multi_xml (~> 0.5)
-      rack (~> 1.2)
     overcommit (0.27.0)
       childprocess (~> 0.5.6)
       iniparse (~> 1.4)
@@ -247,7 +219,6 @@ DEPENDENCIES
   attr_encrypted (~> 1.3)
   brakeman
   byebug
-  coinbase!
   connection_pool (~> 2.2)
   dwolla-ruby (~> 2.6)
   flamegraph
@@ -270,4 +241,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ The schedule of rake tasks is:
 
 - 14:00 UTC (daily): `rake philanthropist:donate`
 - 14:30 UTC (daily): `rake philanthropist:confirm`
-- 15:00 UTC (daily): `rake philanthropist:exchange`
 
 The order of these tasks is the opposite in which value moves through the
 system. While this lengthens the process of donating, it allows for more time to


### PR DESCRIPTION
This commit removes the `coinbase` gem dependency by
removing the code pertaining to automated Coinbase
exchanges. This is because this project has switched
from selling Bitcoin via Coinbase to using Circle, in
order to avoid transaction fees (Coinbase has them,
Circle has none) to pass on the most money directly
to charities.
